### PR TITLE
feat: implement professional PDF export and bump version to v1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ InfraScan offers several scanning modes:
 - **comprehensive**: All scanners combined (Cost + Security + Containers)
 
 **Report Features:**
+- **Professional PDF Export**: Generate beautiful, branded security reports with one click — perfect for compliance and auditing.
 - **Grade Cards**: Visual A-F grades for Overall, Cost, and Security
 - **Risk Assessment**: Low to Critical risk levels
 - **Severity Breakdown**: High/Medium/Low issue counts

--- a/reporter/html_generator.py
+++ b/reporter/html_generator.py
@@ -14,6 +14,7 @@ def generate_standalone_html(report_dict):
     template_path = os.path.join(base_dir, 'templates', 'index.html')
     css_path = os.path.join(base_dir, 'static', 'style.css')
     js_path = os.path.join(base_dir, 'static', 'app.js')
+    pdf_js_path = os.path.join(base_dir, 'static', 'pdf_generator.js')
     logo_path = os.path.join(base_dir, 'static', 'images', 'soldevelo.png')
     
     # Read files
@@ -26,6 +27,9 @@ def generate_standalone_html(report_dict):
             
         with open(js_path, 'r', encoding='utf-8') as f:
             js_content = f.read()
+
+        with open(pdf_js_path, 'r', encoding='utf-8') as f:
+            pdf_js_content = f.read()
             
         with open(logo_path, 'rb') as f:
             logo_b64 = base64.b64encode(f.read()).decode('utf-8')
@@ -63,8 +67,11 @@ def generate_standalone_html(report_dict):
     
     # Protect the app.js script tag from generic cleanup
     js_placeholder = "<!-- APP_JS_PLACEHOLDER -->"
-    js_pattern = r'<script[^>]*src=["\'].*?app\.js.*?["\'][^>]*>\s*</script>'
+    # Match both the new pdf_generator.js and app.js tags
+    js_pattern = r'<script[^>]*src=["\'].*?(app\.js|pdf_generator\.js).*?["\'][^>]*>\s*</script>'
     html_content = re.sub(js_pattern, js_placeholder, html_content)
+    # Remove duplicates if both tags were replaced
+    html_content = re.sub(f"{js_placeholder}\\s*{js_placeholder}", js_placeholder, html_content)
 
     # Clean up ALL remaining Jinja tags (static_version, google_tag_id etc)
     # This must happen before data injection
@@ -75,6 +82,7 @@ def generate_standalone_html(report_dict):
     # Use a safe way to build the script tag without f-string interpolation issues for JS content
     injected_script = "<script>\n"
     injected_script += f"    window.CLI_INJECTED_DATA_B64 = \"{json_b64}\";\n"
+    injected_script += f"    {pdf_js_content}\n"
     injected_script += f"    {js_content}\n"
     injected_script += "</script>"
     

--- a/static/app.js
+++ b/static/app.js
@@ -445,6 +445,46 @@ function initApp() {
         });
     }
 
+    // Export PDF Button — opens a dedicated, beautifully formatted PDF document in a new window
+    const exportPdfBtn = document.getElementById('export-pdf-btn');
+    if (exportPdfBtn) {
+        exportPdfBtn.addEventListener('click', () => {
+            if (!currentResults) return;
+
+            exportPdfBtn.classList.add('exporting');
+            exportPdfBtn.disabled = true;
+            exportPdfBtn.innerHTML = '<span class="export-pdf-icon">⏳</span> Preparing PDF...';
+
+            setTimeout(() => {
+                try {
+                    const html = buildPdfDocument(
+                        currentResults,
+                        currentSummary,
+                        currentMetadata,
+                        currentGradeReport
+                    );
+                    const win = window.open('', '_blank', 'width=1050,height=820,scrollbars=yes,resizable=yes');
+                    if (!win) {
+                        alert('Popup blocked! Please allow popups for this site to export PDF.');
+                        return;
+                    }
+                    win.document.open();
+                    win.document.write(html);
+                    win.document.close();
+                    win.focus();
+                    // Auto-trigger print after fonts load
+                    setTimeout(() => win.print(), 800);
+                } catch (e) {
+                    console.error('PDF generation error:', e);
+                    alert('Could not generate PDF: ' + e.message);
+                } finally {
+                    exportPdfBtn.classList.remove('exporting');
+                    exportPdfBtn.disabled = false;
+                    exportPdfBtn.innerHTML = '<span class="export-pdf-icon">⬇</span> Export PDF';
+                }
+            }, 100);
+        });
+    }
 
 
     function resetScanProgress() {

--- a/static/app.js
+++ b/static/app.js
@@ -448,41 +448,43 @@ function initApp() {
     // Export PDF Button — opens a dedicated, beautifully formatted PDF document in a new window
     const exportPdfBtn = document.getElementById('export-pdf-btn');
     if (exportPdfBtn) {
-        exportPdfBtn.addEventListener('click', () => {
+        exportPdfBtn.addEventListener('click', async () => {
             if (!currentResults) return;
 
             exportPdfBtn.classList.add('exporting');
             exportPdfBtn.disabled = true;
             exportPdfBtn.innerHTML = '<span class="export-pdf-icon">⏳</span> Preparing PDF...';
 
-            setTimeout(() => {
-                try {
-                    const html = buildPdfDocument(
-                        currentResults,
-                        currentSummary,
-                        currentMetadata,
-                        currentGradeReport
-                    );
-                    const win = window.open('', '_blank', 'width=1050,height=820,scrollbars=yes,resizable=yes');
-                    if (!win) {
-                        alert('Popup blocked! Please allow popups for this site to export PDF.');
-                        return;
-                    }
-                    win.document.open();
-                    win.document.write(html);
-                    win.document.close();
-                    win.focus();
-                    // Auto-trigger print after fonts load
-                    setTimeout(() => win.print(), 800);
-                } catch (e) {
-                    console.error('PDF generation error:', e);
-                    alert('Could not generate PDF: ' + e.message);
-                } finally {
-                    exportPdfBtn.classList.remove('exporting');
-                    exportPdfBtn.disabled = false;
-                    exportPdfBtn.innerHTML = '<span class="export-pdf-icon">⬇</span> Export PDF';
+            try {
+                const html = buildPdfDocument(
+                    currentResults,
+                    currentSummary,
+                    currentMetadata,
+                    currentGradeReport
+                );
+                const win = window.open('', '_blank', 'width=1050,height=820,scrollbars=yes,resizable=yes');
+                if (!win) {
+                    alert('Popup blocked! Please allow popups for this site to export PDF.');
+                    return;
                 }
-            }, 100);
+                win.document.open();
+                win.document.write(html);
+                win.document.close();
+                win.focus();
+                
+                // Wait for fonts to load before printing for perfect rendering
+                if (win.document.fonts) {
+                    await win.document.fonts.ready;
+                }
+                win.print();
+            } catch (e) {
+                console.error('PDF generation error:', e);
+                alert('Could not generate PDF: ' + e.message);
+            } finally {
+                exportPdfBtn.classList.remove('exporting');
+                exportPdfBtn.disabled = false;
+                exportPdfBtn.innerHTML = '<span class="export-pdf-icon">⬇</span> Export PDF';
+            }
         });
     }
 

--- a/static/pdf_generator.js
+++ b/static/pdf_generator.js
@@ -1,0 +1,423 @@
+/* InfraScan PDF Report Generator
+ * Generates a standalone, beautifully formatted HTML document in a popup window
+ * and triggers window.print() so the user can save it as PDF.
+ */
+function buildPdfDocument(results, summary, metadata, gradeReport) {
+    const esc = (t) => t == null ? '' : String(t)
+        .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+    // ── Meta ──────────────────────────────────────────────────────────────────
+    const repoName  = esc(metadata?.repository_name || metadata?.repository_url || '—');
+    const repoUrl   = esc(metadata?.repository_url  || '');
+    const branch    = esc(metadata?.branch           || 'default');
+    const scanDate  = esc(metadata?.scan_timestamp   || new Date().toLocaleString());
+    const resources = esc(metadata?.resource_count   || '—');
+    const scannerLabel = {
+        comprehensive: 'Comprehensive (Cost + Security + Containers)',
+        regex:         'Fast — Cost Optimization Only',
+        checkov:       'Security — IaC Security Only',
+        containers:    'Containers — Container Vulnerabilities Only',
+    }[summary?.scanner_used] || esc(summary?.scanner_used || '—');
+
+    // Detect container scanner from findings
+    const containerScannerName =
+        results.some(r => r.scanner === 'grype')        ? 'Grype' :
+        results.some(r => r.scanner === 'docker-scout') ? 'Docker Scout' : null;
+
+    // ── Split findings ────────────────────────────────────────────────────────
+    const costResults      = results.filter(r => r.scanner === 'regex');
+    const iacResults       = results.filter(r => r.scanner === 'checkov');
+    const containerResults = results.filter(r => r.scanner === 'grype' || r.scanner === 'docker-scout');
+
+    // Group by rule_id, deduplicated
+    function groupByRule(arr) {
+        const map = {};
+        arr.forEach(f => {
+            const k = f.rule_id || f.rule_name;
+            if (!map[k]) map[k] = [];
+            if (!map[k].some(e => e.file === f.file && e.line === f.line && e.match_content === f.match_content))
+                map[k].push(f);
+        });
+        const order = {Critical:0,High:1,Medium:2,Low:3,Info:4};
+        return Object.entries(map).sort(([,a],[,b]) =>
+            (order[a[0].severity]||9) - (order[b[0].severity]||9));
+    }
+
+    const costGroups = groupByRule(costResults);
+    const iacGroups  = groupByRule(iacResults);
+
+    // Container: group by image
+    const imageMap = {};
+    containerResults.forEach(f => {
+        const img = f.image || 'Unknown Image';
+        if (!imageMap[img]) imageMap[img] = [];
+        imageMap[img].push(f);
+    });
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+    const SEV_FG = {Critical:'#B91C1C',High:'#C2410C',Medium:'#B45309',Low:'#475569',Info:'#64748B'};
+    const SEV_BG = {Critical:'#FEE2E2',High:'#FFEDD5',Medium:'#FEF3C7',Low:'#F1F5F9',Info:'#F8FAFC'};
+    const sevBadge = (s) =>
+        `<span style="display:inline-block;padding:1px 7px;border-radius:99px;font-size:0.7rem;font-weight:700;background:${SEV_BG[s]||'#F1F5F9'};color:${SEV_FG[s]||'#475569'};">${esc(s)}</span>`;
+
+    const GRADE_COLOR = {A:'#059669',B:'#2563EB',C:'#D97706',D:'#EF4444',F:'#B91C1C'};
+    const gc = (l) => GRADE_COLOR[l] || '#64748B';
+
+    const trunc = (t, n=120) => t ? (t.length > n ? t.substring(0,n)+'…' : t) : '';
+
+    // ── Grade cards ───────────────────────────────────────────────────────────
+    function gradeCard(label, g, icon, accent) {
+        if (!g) return '';
+        const sb = g.severity_breakdown || {};
+        return `<div style="flex:1;min-width:130px;border:1.5px solid #E2E8F0;border-top:4px solid ${accent};border-radius:8px;padding:14px 10px;text-align:center;">
+            <div style="font-size:1.6rem;line-height:1;">${icon}</div>
+            <div style="font-size:0.65rem;text-transform:uppercase;letter-spacing:.07em;color:#64748B;font-weight:700;margin:6px 0 8px;">${label}</div>
+            <div style="font-size:2.4rem;font-weight:900;color:${accent};line-height:1;">${esc(g.letter)}</div>
+            <div style="font-size:0.8rem;color:#64748B;margin-top:4px;">${g.percentage}%</div>
+            <div style="font-size:0.72rem;color:#94A3B8;margin-top:3px;">${g.violations} issues</div>
+            <div style="margin-top:7px;font-size:0.7rem;line-height:1.8;">
+                ${sb.critical>0 ? `<span style="color:#B91C1C;font-weight:700;">${sb.critical} Crit </span>` : ''}
+                ${sb.high>0     ? `<span style="color:#C2410C;font-weight:700;">${sb.high} High </span>` : ''}
+                ${sb.medium>0   ? `<span style="color:#B45309;font-weight:700;">${sb.medium} Med </span>` : ''}
+                ${sb.low>0      ? `<span style="color:#475569;font-weight:700;">${sb.low} Low</span>` : ''}
+            </div>
+        </div>`;
+    }
+
+    const gradesSection = gradeReport ? `
+<section class="section">
+  <h2 class="section-title" style="color:#1E293B;">📊 Infrastructure Report Card</h2>
+  <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:14px;">
+    ${gradeCard('Overall',   gradeReport.overall,   '🎯', gc(gradeReport.overall?.letter))}
+    ${gradeCard('Cost',      gradeReport.cost,      '💰', '#059669')}
+    ${gradeCard('IaC Security', gradeReport.security,'🔒', '#4F46E5')}
+    ${gradeReport.container ? gradeCard('Containers', gradeReport.container,'🐳','#2563EB') : ''}
+  </div>
+  ${(gradeReport.analysis?.recommendations?.length > 0) ? `
+  <div class="infobox">
+    <div class="infobox-title">💡 Key Recommendations</div>
+    <ul style="margin:6px 0 0 0;padding-left:18px;">
+      ${gradeReport.analysis.recommendations.map(r=>`<li style="margin-bottom:3px;">${esc(r)}</li>`).join('')}
+    </ul>
+  </div>` : ''}
+</section>` : '';
+
+    // ── Cost table ────────────────────────────────────────────────────────────
+    const TH = (txt, w='') =>
+        `<th style="text-align:left;padding:7px 8px;font-weight:700;${w?'width:'+w+';':''}">${txt}</th>`;
+
+    function costTable() {
+        if (costGroups.length === 0) return showIaC() || containerScannerName ? `
+<section class="section">
+  <h2 class="section-title" style="color:#059669;">💰 Cost Optimization</h2>
+  <div class="empty-box">✅ No cost issues found.</div>
+</section>` : '';
+
+        const rows = costGroups.map(([,findings],i) => {
+            const f = findings[0];
+            const bg = i%2 ? '#F8FFF9' : '#FFFFFF';
+            const files = findings.slice(0,3).map(fi =>
+                `<div class="cell-small" title="${esc(fi.file)}">${esc(trunc(fi.file,50))}${fi.line?':'+fi.line:''}</div>`).join('')
+                + (findings.length>3 ? `<div class="cell-small muted">+${findings.length-3} more…</div>` : '');
+            return `<tr style="background:${bg};">
+              <td class="td"><div class="rule-name">${esc(f.rule_name)}</div><div class="cell-small muted">${esc(trunc(f.description))}</div></td>
+              <td class="td" style="text-align:center;">${sevBadge(f.severity)}</td>
+              <td class="td" style="text-align:center;font-weight:700;">${findings.length}</td>
+              <td class="td"><span style="font-weight:700;color:#059669;">${esc(f.estimated_savings||'—')}</span></td>
+              <td class="td"><div class="cell-small">${esc(trunc(f.remediation,140))}</div>${files}</td>
+            </tr>`;
+        }).join('');
+
+        return `<section class="section">
+  <h2 class="section-title" style="color:#059669;">💰 Cost Optimization — ${costGroups.length} rules, ${costResults.length} occurrences</h2>
+  <table class="data-table" style="--hdr:#F0FDF4;--hdr-bdr:#A7F3D0;--hdr-fg:#166534;">
+    <thead><tr style="background:var(--hdr);border-bottom:2px solid var(--hdr-bdr);">
+      ${TH('Rule / Description','30%')}${TH('Severity','9%')}${TH('Files','6%')}${TH('Savings','12%')}${TH('Fix & Locations')}
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+    }
+
+    // ── IaC Security table ────────────────────────────────────────────────────
+    function showIaC() { return iacResults.length > 0 || summary?.scanner_used === 'checkov' || summary?.scanner_used === 'comprehensive'; }
+
+    function iacTable() {
+        if (!showIaC() && iacGroups.length === 0) return '';
+        if (iacGroups.length === 0) return `
+<section class="section">
+  <h2 class="section-title" style="color:#4F46E5;">🔒 IaC Security</h2>
+  <div class="empty-box">✅ No IaC security issues found.</div>
+</section>`;
+
+        const rows = iacGroups.map(([ruleId,findings],i) => {
+            const f = findings[0];
+            const bg = i%2 ? '#F8F9FF' : '#FFFFFF';
+            const resources = findings.slice(0,4).map(fi => {
+                const res = fi.match_content?.startsWith('Resource: ')
+                    ? fi.match_content.replace('Resource: ','')
+                    : `${fi.file}${fi.line?':'+fi.line:''}`;
+                return `<div class="cell-small">${esc(trunc(res,60))}</div>`;
+            }).join('') + (findings.length>4?`<div class="cell-small muted">+${findings.length-4} more…</div>`:'');
+            return `<tr style="background:${bg};">
+              <td class="td" style="font-family:monospace;font-size:0.72rem;white-space:nowrap;">${esc(ruleId)}</td>
+              <td class="td"><div class="rule-name">${esc(f.rule_name)}</div><div class="cell-small muted">${esc(trunc(f.description))}</div></td>
+              <td class="td" style="text-align:center;">${sevBadge(f.severity)}</td>
+              <td class="td" style="text-align:center;font-weight:700;">${findings.length}</td>
+              <td class="td">${resources}</td>
+              <td class="td"><div class="cell-small">${esc(trunc(f.remediation,130))}</div></td>
+            </tr>`;
+        }).join('');
+
+        return `<section class="section">
+  <h2 class="section-title" style="color:#4F46E5;">🔒 IaC Security — ${iacGroups.length} checks, ${iacResults.length} occurrences</h2>
+  <table class="data-table" style="--hdr:#EEF2FF;--hdr-bdr:#C7D2FE;--hdr-fg:#3730A3;">
+    <thead><tr style="background:var(--hdr);border-bottom:2px solid var(--hdr-bdr);">
+      ${TH('Check ID','10%')}${TH('Check Name','24%')}${TH('Severity','9%')}${TH('Hits','5%')}${TH('Resources','22%')}${TH('Fix')}
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+    }
+
+    // ── Container Security table ──────────────────────────────────────────────
+    function containerTable() {
+        if (!containerScannerName && containerResults.length === 0) return '';
+        if (containerResults.length === 0) return `
+<section class="section">
+  <h2 class="section-title" style="color:#2563EB;">🐳 Container Security</h2>
+  <div class="empty-box">✅ No container vulnerabilities found.</div>
+</section>`;
+
+        const sortedImages = Object.entries(imageMap).sort((a,b) => {
+            const val = {Critical:4,High:3,Medium:2,Low:1,Info:0};
+            const worstOf = arr => Math.max(...arr.map(f=>val[f.severity]||0));
+            return worstOf(b[1]) - worstOf(a[1]);
+        });
+
+        const rows = sortedImages.flatMap(([image, vulns],imgIdx) => {
+            const ordered = [...vulns].sort((a,b)=>{
+                const v={Critical:4,High:3,Medium:2,Low:1,Info:0};
+                return (v[b.severity]||0)-(v[a.severity]||0);
+            });
+            const imgBg = imgIdx%2 ? '#EFF6FF' : '#F0F9FF';
+            const imgRow = `<tr>
+              <td class="td img-cell" colspan="5" style="background:${imgBg};font-weight:700;color:#1E40AF;padding:8px 10px;">
+                🐳 ${esc(image)}
+                <span style="font-weight:400;color:#64748B;font-size:0.75rem;margin-left:8px;">${vulns.length} vulnerabilities</span>
+                ${containerScannerName ? `<span style="font-weight:400;color:#94A3B8;font-size:0.72rem;margin-left:6px;">via ${esc(containerScannerName)}</span>` : ''}
+              </td>
+            </tr>`;
+            const cveRows = ordered.map(v => `<tr>
+              <td class="td" style="font-family:monospace;font-size:0.72rem;white-space:nowrap;">${esc(v.rule_id||'—')}</td>
+              <td class="td"><div class="rule-name">${esc(v.package)}</div><div class="cell-small muted">v${esc(v.package_version)}</div></td>
+              <td class="td" style="text-align:center;">${sevBadge(v.severity)}</td>
+              <td class="td" style="font-size:0.72rem;">${v.fix_version && v.fix_version!=='N/A' ? `<span style="color:#059669;font-weight:700;">→ ${esc(v.fix_version)}</span>` : '<span class="muted">No fix yet</span>'}</td>
+              <td class="td"><div class="cell-small muted">${esc(trunc(v.description,100))}</div></td>
+            </tr>`).join('');
+            return [imgRow, cveRows];
+        }).join('');
+
+        return `<section class="section">
+  <h2 class="section-title" style="color:#2563EB;">🐳 Container Security — ${containerResults.length} vulnerabilities in ${Object.keys(imageMap).length} image(s)${containerScannerName ? ` · Scanner: <span style="font-weight:600;">${esc(containerScannerName)}</span>` : ''}</h2>
+  <table class="data-table" style="--hdr:#EFF6FF;--hdr-bdr:#BFDBFE;--hdr-fg:#1E40AF;">
+    <thead><tr style="background:var(--hdr);border-bottom:2px solid var(--hdr-bdr);">
+      ${TH('CVE / ID','12%')}${TH('Package','18%')}${TH('Severity','9%')}${TH('Fix Version','12%')}${TH('Description')}
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+    }
+
+    // ── Assemble full document ────────────────────────────────────────────────
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>InfraScan Report — ${repoName}</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 12px;
+    color: #1E293B;
+    background: #FFFFFF;
+    padding: 28px 32px;
+    line-height: 1.5;
+  }
+  @page { size: A4 portrait; margin: 12mm 10mm 16mm 10mm; }
+  @media print {
+    body { padding: 0; }
+    .no-print { display: none !important; }
+    section { page-break-inside: avoid; }
+    tr { page-break-inside: avoid; }
+  }
+
+  /* ── Header ── */
+  .pdf-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 3px solid #4F46E5;
+    padding-bottom: 14px;
+    margin-bottom: 20px;
+  }
+  .pdf-logo-block { display: flex; align-items: center; gap: 12px; }
+  .pdf-logo-name {
+    font-size: 1.6rem;
+    font-weight: 900;
+    background: linear-gradient(135deg, #4F46E5, #818CF8);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    letter-spacing: -0.5px;
+  }
+  .pdf-logo-tag {
+    font-size: 0.7rem;
+    color: #64748B;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  .pdf-report-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #4F46E5;
+    text-align: right;
+  }
+  .pdf-soldevelo {
+    font-size: 0.72rem;
+    color: #94A3B8;
+    text-align: right;
+    margin-top: 2px;
+  }
+
+  /* ── Sections ── */
+  .section { margin-bottom: 24px; }
+  .section-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding-bottom: 6px;
+    border-bottom: 2px solid #E2E8F0;
+    margin-bottom: 12px;
+  }
+
+  /* ── Metadata table ── */
+  .meta-table { width: 100%; border-collapse: collapse; margin-bottom: 0; }
+  .meta-table td { padding: 5px 10px; font-size: 0.78rem; border-bottom: 1px solid #F1F5F9; }
+  .meta-table td:first-child { color: #64748B; font-weight: 600; width: 160px; white-space: nowrap; }
+  .meta-table td:last-child  { color: #1E293B; }
+  .meta-table tr:last-child td { border-bottom: none; }
+
+  /* ── Data tables ── */
+  .data-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; }
+  .data-table thead th { padding: 7px 8px; color: var(--hdr-fg); font-weight: 700; }
+  .data-table tbody tr { border-bottom: 1px solid #F1F5F9; }
+  .data-table tbody tr:last-child { border-bottom: none; }
+  .td { padding: 6px 8px; vertical-align: top; }
+  .rule-name { font-weight: 600; color: #1E293B; margin-bottom: 2px; }
+  .cell-small { font-size: 0.7rem; color: #475569; line-height: 1.4; }
+  .muted { color: #94A3B8 !important; }
+  .img-cell { border-top: 2px solid #BFDBFE; }
+
+  /* ── Info box ── */
+  .infobox {
+    background: #F8FAFC;
+    border: 1px solid #E2E8F0;
+    border-left: 4px solid #4F46E5;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.78rem;
+    color: #475569;
+  }
+  .infobox-title { font-weight: 700; color: #1E293B; margin-bottom: 4px; }
+  .empty-box {
+    background: #F8FAFC;
+    border: 1px dashed #CBD5E1;
+    border-radius: 6px;
+    padding: 14px;
+    text-align: center;
+    color: #64748B;
+    font-size: 0.8rem;
+  }
+
+  /* ── Footer ── */
+  .pdf-footer {
+    margin-top: 28px;
+    padding-top: 10px;
+    border-top: 1px solid #E2E8F0;
+    font-size: 0.7rem;
+    color: #94A3B8;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  /* ── Print button (hidden in print) ── */
+  .print-btn {
+    position: fixed; bottom: 24px; right: 24px;
+    background: #4F46E5; color: #fff; border: none;
+    border-radius: 8px; padding: 10px 20px;
+    font-size: 0.85rem; font-weight: 700;
+    cursor: pointer; box-shadow: 0 4px 12px rgba(79,70,229,.4);
+    transition: background .2s;
+  }
+  .print-btn:hover { background: #4338CA; }
+</style>
+</head>
+<body>
+
+<!-- ── HEADER ── -->
+<header class="pdf-header">
+  <div class="pdf-logo-block">
+    <div>
+      <div class="pdf-logo-name">🔍 InfraScan</div>
+      <div class="pdf-logo-tag">Infrastructure Security Report</div>
+    </div>
+  </div>
+  <div>
+    <div class="pdf-report-title">${repoName}</div>
+    <div class="pdf-soldevelo">by SolDevelo · infrascan.soldevelo.com</div>
+  </div>
+</header>
+
+<!-- ── SCAN METADATA ── -->
+<section class="section">
+  <h2 class="section-title" style="color:#1E293B;">📋 Scan Information</h2>
+  <table class="meta-table">
+    <tr><td>Repository</td><td><a href="${repoUrl}" style="color:#4F46E5;text-decoration:none;">${repoName}</a></td></tr>
+    <tr><td>Branch</td><td>${branch}</td></tr>
+    <tr><td>Scan Date</td><td>${scanDate}</td></tr>
+    <tr><td>Analysis Scope</td><td>${scannerLabel}</td></tr>
+    ${containerScannerName ? `<tr><td>Container Scanner</td><td>${esc(containerScannerName)}</td></tr>` : ''}
+    <tr><td>Resources Scanned</td><td>${resources}</td></tr>
+    <tr><td>Total Findings</td><td><strong>${results.length}</strong>
+      (${costResults.length} Cost · ${iacResults.length} IaC Security · ${containerResults.length} Container)</td></tr>
+  </table>
+</section>
+
+<!-- ── GRADE REPORT CARD ── -->
+${gradesSection}
+
+<!-- ── COST FINDINGS ── -->
+${costTable()}
+
+<!-- ── IAC SECURITY FINDINGS ── -->
+${iacTable()}
+
+<!-- ── CONTAINER SECURITY FINDINGS ── -->
+${containerTable()}
+
+<!-- ── FOOTER ── -->
+<div class="pdf-footer">
+  <span>Generated by <strong>InfraScan</strong> · <a href="https://infrascan.soldevelo.com" style="color:#4F46E5;text-decoration:none;">infrascan.soldevelo.com</a></span>
+  <span>© 2026 <a href="https://soldevelo.com" style="color:#4F46E5;text-decoration:none;">SolDevelo</a> · ${scanDate}</span>
+</div>
+
+<!-- ── PRINT BUTTON (hidden when printing) ── -->
+<button class="print-btn no-print" onclick="window.print()">⬇ Save as PDF</button>
+
+</body>
+</html>`;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -2813,3 +2813,357 @@ textarea:focus {
 .usage-footer-premium a:hover::after {
     transform: scaleX(1);
 }
+
+/* ============================================
+   Export PDF Button
+   ============================================ */
+.export-pdf-btn {
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(59, 130, 246, 0.15));
+    border-color: rgba(16, 185, 129, 0.4);
+    color: #10B981;
+    gap: 0.4rem;
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.export-pdf-btn:hover {
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.25), rgba(59, 130, 246, 0.25));
+    border-color: #10B981;
+    color: #34D399;
+    box-shadow: 0 0 18px rgba(16, 185, 129, 0.2);
+    transform: translateY(-1px);
+}
+
+.export-pdf-btn:active {
+    transform: translateY(0);
+}
+
+.export-pdf-btn.exporting {
+    opacity: 0.7;
+    cursor: wait;
+}
+
+.export-pdf-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+/* ============================================
+   Print / PDF Export Styles
+   ============================================ */
+@media print {
+    /* ---- Reset & page setup ---- */
+    @page {
+        size: A4 portrait;
+        margin: 15mm 12mm 18mm 12mm;
+    }
+
+    /* ---- Force light background so content is readable ---- */
+    :root {
+        --bg-color: #ffffff;
+        --card-bg: #f8fafc;
+        --text-main: #0f172a;
+        --text-muted: #475569;
+        --border: #cbd5e1;
+        --primary: #4f46e5;
+        --success: #059669;
+        --warning: #d97706;
+        --danger: #dc2626;
+        --glass: #f1f5f9;
+        --glass-border: #e2e8f0;
+    }
+
+    * {
+        print-color-adjust: exact;
+        -webkit-print-color-adjust: exact;
+        color-adjust: exact;
+    }
+
+    body {
+        background: #ffffff !important;
+        color: #0f172a !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        display: block !important;
+        font-size: 10pt;
+        line-height: 1.5;
+    }
+
+    /* ---- Hide UI chrome ---- */
+    header,
+    footer,
+    .tabs,
+    .tab-content,
+    .results-actions,
+    #share-link-container,
+    .soft-sell,
+    #scroll-to-top,
+    #newsletter-modal,
+    #feedback-modal,
+    #toast-container,
+    #loading,
+    #scan-input-container,
+    .landing-info,
+    #recent-scans-tab,
+    #release-notes-tab,
+    #local-usage-tab,
+    .github-stars-badge,
+    .github-stars-badge-footer {
+        display: none !important;
+    }
+
+    /* ---- Container: full width, no transitions ---- */
+    .container,
+    .container.expanded {
+        max-width: 100% !important;
+        width: 100% !important;
+        transition: none !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* ---- Results area: always visible ---- */
+    #results-area {
+        display: block !important;
+        margin-top: 0 !important;
+    }
+
+    /* ---- PDF header banner ---- */
+    #results-area::before {
+        content: "InfraScan — Infrastructure Security Report";
+        display: block;
+        font-size: 18pt;
+        font-weight: 800;
+        color: #4f46e5;
+        border-bottom: 3px solid #4f46e5;
+        padding-bottom: 6pt;
+        margin-bottom: 14pt;
+        letter-spacing: -0.3px;
+    }
+
+    /* ---- Page breaks ---- */
+    .results-column,
+    .finding-card,
+    .grade-report-section,
+    .report-metadata {
+        page-break-inside: avoid;
+        break-inside: avoid;
+    }
+
+    .results-column {
+        page-break-before: auto;
+    }
+
+    /* ---- Layout: switch to single column for print ---- */
+    .results-grid-layout {
+        display: block !important;
+        gap: 0 !important;
+    }
+
+    .results-column {
+        margin-bottom: 1.5rem;
+        border: 1px solid #cbd5e1 !important;
+        background: #f8fafc !important;
+        border-radius: 0.5rem;
+        padding: 0.75rem !important;
+    }
+
+    /* ---- Typography adjustments ---- */
+    .stat-value {
+        color: #0f172a !important;
+        font-size: 1.4rem !important;
+    }
+
+    .stat-label {
+        color: #475569 !important;
+    }
+
+    .stat-card {
+        background: #f1f5f9 !important;
+        border-color: #cbd5e1 !important;
+    }
+
+    .stat-card.total {
+        background: linear-gradient(135deg, #f1f5f9, #eef2ff) !important;
+    }
+
+    .finding-card {
+        background: #f8fafc !important;
+        border-color: #cbd5e1 !important;
+        margin-bottom: 0.75rem;
+        padding: 1rem !important;
+    }
+
+    .finding-title {
+        color: #0f172a !important;
+    }
+
+    .finding-detail {
+        color: #475569 !important;
+    }
+
+    .code-block {
+        background: #f1f5f9 !important;
+        color: #1e293b !important;
+        border-color: #cbd5e1 !important;
+        font-size: 8pt !important;
+    }
+
+    /* ---- Grade cards ---- */
+    .grade-report-section {
+        background: #f8fafc !important;
+        border: 1px solid #cbd5e1 !important;
+        border-radius: 0.5rem;
+        padding: 1rem !important;
+        margin-bottom: 1.5rem;
+    }
+
+    .grade-card {
+        background: #f1f5f9 !important;
+        border: 1px solid #cbd5e1 !important;
+    }
+
+    .grade-letter {
+        color: #ffffff !important;
+        print-color-adjust: exact;
+    }
+
+    .grade-percentage {
+        color: #0f172a !important;
+    }
+
+    .grade-detail-label,
+    .grade-detail-value {
+        color: #475569 !important;
+    }
+
+    .section-title,
+    .column-title,
+    #results-area h2 {
+        color: #0f172a !important;
+    }
+
+    .column-title.cost {
+        color: #059669 !important;
+        border-bottom-color: #059669 !important;
+    }
+
+    .column-title.security {
+        color: #4f46e5 !important;
+        border-bottom-color: #4f46e5 !important;
+    }
+
+    /* ---- Report metadata ---- */
+    .report-metadata {
+        background: #f1f5f9 !important;
+        border: 1px solid #cbd5e1 !important;
+        border-radius: 0.5rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .metadata-label {
+        color: #475569 !important;
+    }
+
+    .metadata-value,
+    .metadata-value a {
+        color: #0f172a !important;
+    }
+
+    /* ---- Summary grid ---- */
+    .summary-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)) !important;
+    }
+
+    /* ---- Container findings: expand all accordion sections ---- */
+    .image-card-content,
+    .cve-list,
+    .cve-details {
+        display: block !important;
+    }
+
+    .image-card {
+        background: #f8fafc !important;
+        border: 1px solid #cbd5e1 !important;
+    }
+
+    .image-card-header {
+        cursor: default !important;
+    }
+
+    .expand-icon,
+    .severity-expand-icon,
+    .cve-expand-icon {
+        display: none !important;
+    }
+
+    /* ---- Severity badges stay colored ---- */
+    .severity-badge.Critical {
+        background: rgba(220, 38, 38, 0.15) !important;
+        color: #dc2626 !important;
+    }
+
+    .severity-badge.High {
+        background: rgba(239, 68, 68, 0.15) !important;
+        color: #ef4444 !important;
+    }
+
+    .severity-badge.Medium {
+        background: rgba(245, 158, 11, 0.15) !important;
+        color: #d97706 !important;
+    }
+
+    .severity-badge.Low {
+        background: rgba(148, 163, 184, 0.15) !important;
+        color: #64748b !important;
+    }
+
+    .severity-tag.critical-tag { color: #dc2626 !important; }
+    .severity-tag.high-tag     { color: #ef4444 !important; }
+    .severity-tag.medium-tag   { color: #d97706 !important; }
+    .severity-tag.low-tag      { color: #64748b !important; }
+
+    /* ---- Recommendations ---- */
+    .recommendations-section {
+        background: #f1f5f9 !important;
+        border: 1px solid #cbd5e1 !important;
+        border-radius: 0.5rem;
+        padding: 0.75rem !important;
+    }
+
+    .recommendations-title {
+        color: #0f172a !important;
+    }
+
+    .recommendations-list li {
+        color: #1e293b !important;
+    }
+
+    /* ---- Links ---- */
+    a {
+        color: #4f46e5 !important;
+        text-decoration: none;
+    }
+
+    /* ---- Empty states ---- */
+    .empty-state {
+        background: #f1f5f9 !important;
+        border-color: #cbd5e1 !important;
+        color: #475569 !important;
+    }
+
+    /* ---- PDF footer ---- */
+    #results-area::after {
+        content: "Generated by InfraScan — infrascan.soldevelo.com — " attr(data-scan-date);
+        display: block;
+        font-size: 8pt;
+        color: #94a3b8;
+        text-align: center;
+        margin-top: 2rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid #e2e8f0;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -230,6 +230,15 @@
                 <div class="release-notes-container">
                     <div class="release-entry">
                         <div class="release-header">
+                            <span class="version">v1.0.7</span>
+                            <span class="date">May 13, 2026</span>
+                        </div>
+                        <ul class="release-list">
+                            <li><strong>PDF Export</strong>: Reports can now be exported as a print-ready PDF directly from the browser — ideal for sharing with compliance and security teams.</li>
+                        </ul>
+                    </div>
+                    <div class="release-entry">
+                        <div class="release-header">
                             <span class="version">v1.0.5</span>
                             <span class="date">April 10, 2026</span>
                         </div>
@@ -468,6 +477,9 @@
                     <div class="results-actions">
                         <button class="secondary-btn" id="new-scan-btn">New Scan</button>
                         <button class="secondary-btn" id="share-btn">Share Results</button>
+                        <button class="secondary-btn export-pdf-btn" id="export-pdf-btn" title="Export report as PDF">
+                            <span class="export-pdf-icon">⬇</span> Export PDF
+                        </button>
                     </div>
                 </div>
 
@@ -496,7 +508,7 @@
                 <button id="open-feedback-btn" class="text-link-btn">Leave Feedback</button>
             </p>
 
-            <p>InfraScan v1.0.5 &copy; 2026 SolDevelo. Advanced Infrastructure Auditor.</p>
+            <p>InfraScan v1.0.7 &copy; 2026 SolDevelo. Advanced Infrastructure Auditor.</p>
             <p style="font-size: 0.9rem; opacity: 0.8; margin-top:4px;">This tool is <a
                     href="https://github.com/SolDevelo/InfraScan" target="_blank"><strong>Open Source</strong></a> –
                 contributions are welcome!
@@ -595,6 +607,7 @@
     <!-- Toast Container -->
     <div id="toast-container"></div>
 
+    <script src="{{ url_for('static', filename='pdf_generator.js') }}?v={{ static_version }}"></script>
     <script src="{{ url_for('static', filename='app.js') }}?v={{ static_version }}"></script>
 </body>
 


### PR DESCRIPTION
Adds PDF export functionality for **InfraScan** reports.

Users can now generate a professional, print-ready PDF version of scan results directly from the browser, making it easier to share reports with compliance, security, and auditing teams.

Issue: https://github.com/SolDevelo/InfraScan/issues/51