### PR TITLE
feat: add Ansible support and smart multi-framework detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ InfraScan helps engineering teams detect cloud cost waste, security risks, and c
 ✅ Runs locally or inside your pipelines  
 ✅ No vendor lock-in  
 ✅ Transparent grading and rules  
-✅ Built for Terraform, Kubernetes, Helm, CloudFormation, and containers
+✅ Built for Terraform, Kubernetes, Helm, CloudFormation, Ansible, and containers
 
 Unlike closed SaaS scanners, InfraScan executes entirely in your environment, making it suitable for security-conscious and regulated organizations.
 
@@ -153,7 +153,11 @@ docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework kubernetes --sca
 - `--scanner`: `regex`, `checkov`, `containers`, `comprehensive` (default: `comprehensive`). You can combine multiple scanners using comma (e.g. `--scanner regex,containers`).
 - `--format`: `text`, `json`, or `html` — standalone interactive HTML report (default: `text`)
 - `--out`: Path where output file is saved (e.g. `/scan/report.html`)
-- `--framework`: `auto`, `terraform`, `kubernetes`, `cloudformation`, `helm` (default: `auto`). When set to `auto`, InfraScan detects the framework automatically based on file contents.
+- `--framework`: `smart`, `auto`, `terraform`, `kubernetes`, `cloudformation`, `helm`, `ansible`, `all` (default: `smart`). 
+  - **`smart` (default)**: Intelligently detects the framework. If multiple frameworks are found (e.g., Terraform + Ansible + Kubernetes), automatically scans **all of them** for comprehensive coverage. If only one framework is detected, scans just that one for faster results.
+  - **`auto`**: Auto-detects the framework but picks only the dominant one. Shows a warning if other frameworks are ignored. Useful for projects that intentionally use one primary IaC tool.
+  - **`all`**: Explicitly scans all frameworks (terraform, kubernetes, cloudformation, helm, ansible).
+  - **Explicit framework**: Scan only that specific framework (terraform, kubernetes, etc.).
 - `-f`, `--include`: Select specific files or directories to scan. Can be used multiple times (e.g., `-f dir1 -f file2.tf`). This is useful in large repositories to avoid scanning redundant or test deployments.
 - `--download-external-modules`: Allow Checkov to download external modules (Terraform/etc)
 - `--fail-on`: Exit code 1 when: `any` findings, `high_critical` findings, specific grade threshold (`grade_a` through `grade_f`), or priority threshold (`priority_critical` through `priority_info`). Fails if the result matches or is worse than the specified criteria.
@@ -246,7 +250,31 @@ docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework kubernetes --sca
 docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework kubernetes --scanner containers
 ```
 
-## 🐳 Advanced Container Scanning
+## � Ansible Support
+
+InfraScan natively supports **Ansible playbooks** (`.yml`/`.yaml`). When Ansible files are detected (files containing `hosts:` and `tasks:` or `roles:` keys), InfraScan will:
+
+- **Auto-detect the framework**: If your project contains more Ansible playbooks than other IaC files, InfraScan will automatically switch to Ansible mode. You can also force it with `--framework ansible`.
+- **Security scanning (Checkov)**: Runs Ansible-specific Checkov rules (CKV_ANSIBLE_*) to detect security issues such as disabled certificate validation, hardcoded secrets, unsafe shell operations, and other misconfigurations.
+- **Task and handler counting**: InfraScan counts all tasks and handlers in your playbooks to provide comprehensive reporting.
+- **Multi-document support**: Files with multiple plays or multiple YAML documents separated by `---` are fully supported.
+
+**Example — scanning Ansible playbooks:**
+```bash
+# Auto-detected
+docker run --rm -v $(pwd):/scan soldevelo/infrascan --scanner comprehensive
+
+# Explicit framework
+docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework ansible --scanner comprehensive
+
+# Security checks only
+docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework ansible --scanner checkov
+
+# Scan specific Ansible files
+docker run --rm -v $(pwd):/scan soldevelo/infrascan --framework ansible -f playbooks/ -f roles/
+```
+
+## �🐳 Advanced Container Scanning
 
 InfraScan supports advanced container scanning features:
 - **Image discovery**: Images are automatically extracted from **Docker Compose files** (`docker-compose.yml`, `compose.yaml`) **and Kubernetes manifests** (`Deployment`, `StatefulSet`, `Pod`, etc.).

--- a/app.py
+++ b/app.py
@@ -327,7 +327,7 @@ def scan_github():
             raise clone_error
         
         # Scan directory and get results with resource count
-        results, resource_count, recommendations = scan_directory(temp_dir, scanner_type=scanner_type, framework='terraform')
+        results, resource_count, recommendations = scan_directory(temp_dir, scanner_type=scanner_type, framework='smart')
         
         # Generate comprehensive report with grades
         report_generator = ReportGenerator()

--- a/cli.py
+++ b/cli.py
@@ -98,9 +98,9 @@ def setup_args():
 
     parser.add_argument(
         "--framework",
-        default="auto",
-        choices=["auto", "terraform", "kubernetes", "cloudformation", "helm", "all"],
-        help="IaC framework type (default: auto-detect)"
+        default="smart",
+        choices=["smart", "auto", "terraform", "kubernetes", "cloudformation", "helm", "ansible", "all"],
+        help="IaC framework type (default: smart). 'smart' automatically uses 'all' for multi-framework projects"
     )
 
     parser.add_argument(

--- a/scanner/checkov_scanner.py
+++ b/scanner/checkov_scanner.py
@@ -119,7 +119,13 @@ def parse_checkov_json_output(report_data: Dict[str, Any], base_path: str) -> Li
         # Checkov JSON structure can vary:
         # Option 1: {"check_type": "terraform", "results": {"failed_checks": [...]}}
         # Option 2: {"results": {"terraform": {"failed_checks": [...]}}}
-        
+        # Option 3: [ {report}, {report}, ... ] - a list of per-framework reports,
+        #           returned when scanning multiple frameworks (e.g. --framework all)
+        if isinstance(report_data, list):
+            for report in report_data:
+                findings.extend(parse_checkov_json_output(report, base_path))
+            return findings
+
         results = report_data.get('results', {})
         
         # Check if failed_checks is directly under results

--- a/scanner/parser.py
+++ b/scanner/parser.py
@@ -18,6 +18,63 @@ def is_container_scanner_available():
     else:  # docker-scout (default)
         return is_docker_scout_available()
 
+def detect_all_frameworks(path: str = None, files: list = None) -> list:
+    """
+    Detect ALL IaC frameworks present in the directory or list of files.
+    Returns a list of detected frameworks.
+    
+    Returns:
+    - List of detected frameworks (e.g., ['terraform', 'kubernetes', 'ansible'])
+    """
+    detected = []
+    
+    scan_files = []
+    if files:
+        scan_files = files
+    elif path:
+        for root, dirs, f_list in os.walk(path):
+            for file in f_list:
+                scan_files.append(os.path.join(root, file))
+    
+    tf_files = 0
+    k8s_files = 0
+    cfn_files = 0
+    helm_files = 0
+    ansible_files = 0
+    
+    for full_path in scan_files:
+        file = os.path.basename(full_path)
+        if file.endswith('.tf'):
+            tf_files += 1
+        elif file == 'Chart.yaml' or file == 'Chart.yml':
+            helm_files += 1
+        elif file.endswith(('.yml', '.yaml')):
+            try:
+                with open(full_path, 'r', encoding='utf-8') as f:
+                    head = f.read(1024)
+                    if 'apiVersion:' in head and 'kind:' in head:
+                        k8s_files += 1
+                    elif 'AWSTemplateFormatVersion' in head:
+                        cfn_files += 1
+                    elif ('hosts:' in head or '- hosts:' in head) and ('tasks:' in head or 'roles:' in head or 'play' in head):
+                        ansible_files += 1
+            except Exception:
+                continue
+    
+    # Build list of detected frameworks
+    if tf_files > 0:
+        detected.append('terraform')
+    if k8s_files > 0:
+        detected.append('kubernetes')
+    if cfn_files > 0:
+        detected.append('cloudformation')
+    if helm_files > 0:
+        detected.append('helm')
+    if ansible_files > 0:
+        detected.append('ansible')
+    
+    return detected if detected else ['all']
+
 def detect_framework(path: str = None, files: list = None) -> str:
     """
     Detect the IaC framework used in the directory or list of files.
@@ -27,12 +84,14 @@ def detect_framework(path: str = None, files: list = None) -> str:
     - 'kubernetes'
     - 'cloudformation'
     - 'helm'
-    - 'all' (fallback for Docker/secrets/actions/etc.)
+    - 'ansible'
+    - 'all' (when multiple frameworks are detected, or fallback for Docker/secrets/actions/etc.)
     """
     tf_files = 0
     k8s_files = 0
     cfn_files = 0
     helm_files = 0
+    ansible_files = 0
     
     scan_files = []
     if files:
@@ -57,14 +116,27 @@ def detect_framework(path: str = None, files: list = None) -> str:
                         k8s_files += 1
                     elif 'AWSTemplateFormatVersion' in head:
                         cfn_files += 1
+                    elif ('hosts:' in head or '- hosts:' in head) and ('tasks:' in head or 'roles:' in head or 'play' in head):
+                        # Ansible playbook detection
+                        ansible_files += 1
             except Exception:
                 continue
     
-    if k8s_files > tf_files and k8s_files > cfn_files and k8s_files > helm_files:
+    # Count how many frameworks were detected
+    framework_count = sum([1 for x in [tf_files, k8s_files, cfn_files, helm_files, ansible_files] if x > 0])
+    
+    # If multiple frameworks detected - return 'all' for comprehensive scanning
+    if framework_count > 1:
+        return 'all'
+    
+    # If only one framework - return the specific one
+    if ansible_files > 0:
+        return 'ansible'
+    if k8s_files > 0:
         return 'kubernetes'
-    if cfn_files > tf_files and cfn_files > helm_files:
+    if cfn_files > 0:
         return 'cloudformation'
-    if helm_files > tf_files:
+    if helm_files > 0:
         return 'helm'
     if tf_files > 0:
         return 'terraform'
@@ -142,6 +214,42 @@ def count_resources(path=None, framework='terraform', files=None):
                         services = compose_data['services']
                         if isinstance(services, dict):
                             resource_count += len(services)
+            except Exception:
+                continue
+    
+    if framework in ('ansible', 'all'):
+        import yaml
+        scan_files_ansible = []
+        if files:
+            scan_files_ansible = [f for f in files if f.endswith(('.yml', '.yaml'))]
+        else:
+            for root, dirs, f_list in os.walk(path):
+                for file in f_list:
+                    if file.endswith(('.yml', '.yaml')):
+                        scan_files_ansible.append(os.path.join(root, file))
+        
+        for ansible_file in scan_files_ansible:
+            try:
+                with open(ansible_file, 'r', encoding='utf-8') as f:
+                    # Count plays and tasks in Ansible playbooks
+                    docs = yaml.safe_load_all(f)
+                    for doc in docs:
+                        if doc and isinstance(doc, list):
+                            # Ansible playbooks are lists of plays
+                            for play in doc:
+                                if isinstance(play, dict):
+                                    # Count tasks in each play
+                                    if 'tasks' in play and isinstance(play['tasks'], list):
+                                        resource_count += len(play['tasks'])
+                                    # Count handlers in each play
+                                    if 'handlers' in play and isinstance(play['handlers'], list):
+                                        resource_count += len(play['handlers'])
+                        elif doc and isinstance(doc, dict) and 'tasks' in doc:
+                            # Single play format
+                            if isinstance(doc['tasks'], list):
+                                resource_count += len(doc['tasks'])
+                            if 'handlers' in doc and isinstance(doc['handlers'], list):
+                                resource_count += len(doc['handlers'])
             except Exception:
                 continue
     
@@ -227,9 +335,44 @@ def scan_directory(path, scanner_type='regex', framework='terraform', download_e
             return [], 0, []
 
     # Auto-detect framework if needed
-    if framework == 'auto' or not framework:
-        framework = detect_framework(path, files=resolved_files)
-        print(f"Detected framework: {framework}")
+    if framework == 'smart' or framework == 'auto' or not framework:
+        all_frameworks = detect_all_frameworks(path, files=resolved_files)
+        
+        # For 'smart' mode: detect all frameworks and use 'all' if multiple are found
+        if framework == 'smart':
+            if len(all_frameworks) > 1:
+                framework = 'all'
+                print(f"[i] Multiple IaC frameworks detected: {', '.join(all_frameworks)}")
+                print("[i] Scanning all frameworks for comprehensive coverage")
+            else:
+                framework = all_frameworks[0] if all_frameworks else 'all'
+                print(f"[i] Detected framework: {framework}")
+        else:
+            # For 'auto' mode: traditional behavior - pick the dominant one
+            # Don't use detect_framework() directly as it returns 'all' for multiple frameworks
+            # Instead, manually pick the dominant one
+            framework_counts = {
+                'terraform': 0,
+                'kubernetes': 0,
+                'ansible': 0,
+                'cloudformation': 0,
+                'helm': 0
+            }
+            for fw in all_frameworks:
+                framework_counts[fw] = 1
+            
+            # Pick the one that was detected (or first one if tie)
+            dominant = max(all_frameworks, key=lambda x: (framework_counts[x], all_frameworks.index(x)), default='all')
+            framework = dominant
+            print(f"Detected framework: {framework}")
+            
+            # Show warning if multiple frameworks exist but only one is being scanned
+            if len(all_frameworks) > 1:
+                ignored = [f for f in all_frameworks if f != framework]
+                print(f"[!] WARNING: Detected {len(all_frameworks)} framework types: {', '.join(all_frameworks)}")
+                print(f"[!] Only scanning: {framework}")
+                print(f"[!] Ignored: {', '.join(ignored)}")
+                print("[!] To scan all frameworks, use: --framework all")
 
     # Count resources for reporting
     resource_count = count_resources(path, framework, files=resolved_files)


### PR DESCRIPTION
## Summary

* Added native Ansible support with framework auto-detection and resource counting
* Introduced new `smart` framework mode for automatic multi-framework scanning
* Enhanced Checkov parsing to support multi-framework reports
* Updated CLI defaults and documentation for new framework handling logic

## Changes

* Added Ansible detection and scanning support (`--framework ansible`)
* Added `smart` mode as the default framework detection strategy
* Improved multi-framework detection and warnings in `auto` mode
* Added Ansible task/handler counting for reporting
* Updated README with new framework options and examples

Closes #80