### PR TITLE
fix(rules): lower COST-011 Missing AWS Budget severity to Low

### DIFF
--- a/rules/definitions.py
+++ b/rules/definitions.py
@@ -277,7 +277,7 @@ RULES = [
     InverseRegexRule(
         id="COST-011",
         name="Missing AWS Budget",
-        severity="High",
+        severity="Low",
         description="No AWS budget configured. Budgets help monitor and control spending with alerts.",
         remediation="Create AWS budgets with alerts for forecasted and actual costs to avoid unexpected charges.",
         estimated_savings="Prevention of cost overruns (potentially thousands)",


### PR DESCRIPTION
## Summary
Lowers the severity of `COST-011` ("Missing AWS Budget") from **High** to **Low**, as discussed in #29.

AWS Budgets are commonly defined outside of Terraform — at the AWS Organization level, manually in the console, or in a separate stack. Flagging a missing `aws_budgets_budget` as **High** is therefore too aggressive and can unfairly drag down the cost grade or trip `--fail-on high_critical` CI gates.

## Change
- `rules/definitions.py`: `COST-011` `severity="High"` → `severity="Low"`

## Verification
Ran the regex scanner against a fixture containing `provider "aws"` and no budget resource:

```
>>> Cost Optimization
  [LOW] COST-011: No AWS budget configured. Budgets help monitor and control spending with alerts.
```

The rule still fires correctly, now at **Low** severity.

Fixes #29