### PR TITLE
fix: link Recent Scans repository titles to reports

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -911,7 +911,7 @@ function initApp() {
         return `
         <div class="scan-history-card">
             <div class="scan-history-main">
-                <a class="scan-repo-name" href="${escapeHtml(scan.repository_url)}" target="_blank" rel="noopener noreferrer">
+                <a class="scan-repo-name" href="${viewUrl}" target="_blank">
                     <span class="scan-repo-icon">📦</span>${escapeHtml(scan.repository_name)}
                 </a>
                 <div class="scan-grades">


### PR DESCRIPTION
## Description

### Summary

Update repository title links in the **Recent Scans** section to point to the corresponding InfraScan report instead of the source GitHub repository.

### Changes

* Replaced `scan.repository_url` with `viewUrl` for repository title links.
* Repository titles now navigate to the same destination as the existing **"View Full Report →"** action.
* Removed the dependency on GitHub repository URLs for Recent Scans navigation.

### Before

* Clicking `📦 repository-name` opened the GitHub repository.
* Clicking **"View Full Report →"** opened the InfraScan report.

### After

* Clicking `📦 repository-name` opens the InfraScan report.
* Clicking **"View Full Report →"** opens the same InfraScan report.

### Acceptance Criteria

* [x] Repository titles open the corresponding scan report.
* [x] Repository titles and **"View Full Report →"** use the same URL.
* [x] No GitHub repository links remain attached to repository titles.
* [x] Existing report links continue to work unchanged.
* [x] Change applies to all entries rendered in the Recent Scans list.

### Testing

Verified that clicking both:

* Repository title (`📦 repository-name`)
* **View Full Report →**

results in navigation to the same report page.
